### PR TITLE
fix: add new region 'sto2' for Stockholm - Bromma in server regions

### DIFF
--- a/src/components/ServerCard.js
+++ b/src/components/ServerCard.js
@@ -5,7 +5,7 @@ class ServerCard {
     static REGIONS = {
         'North America': ['atl', 'dfw', 'eat', 'iad', 'lax', 'ord', 'sea'],
         'South America': ['gru', 'scl', 'lim', 'eze'],
-        'Europe': ['ams', 'fra', 'hel', 'lhr', 'mad', 'par', 'sto', 'vie', 'waw'],
+        'Europe': ['ams', 'fra', 'hel', 'lhr', 'mad', 'par', 'sto', 'sto2', 'vie', 'waw'],
         'Asia': ['bom', 'dxb', 'hkg', 'sgp', 'tyo', 'seo'],
         'China': ['ctu', 'pek', 'pvg', 'sha', 'tsn'],
         'Australia': ['syd']
@@ -35,6 +35,7 @@ class ServerCard {
         'mad': '🇪🇸', // Madrid
         'par': '🇫🇷', // Paris
         'sto': '🇸🇪', // Stockholm
+        'sto2': '🇸🇪', // Stockholm - Bromma
         'vie': '🇦🇹', // Vienna
         'waw': '🇵🇱', // Warsaw
 


### PR DESCRIPTION
I added sto2 to it..

Unfortunately tool is not working on linux for me, still connected to blocked regions.